### PR TITLE
Add ClinicalTrial AI product requirements document

### DIFF
--- a/ClinicalTrial_AI_PRD.md
+++ b/ClinicalTrial_AI_PRD.md
@@ -1,0 +1,150 @@
+# ClinicalTrial AI – Product Requirements Document (PRD)
+
+## 1. Product Overview
+
+**Product Name:** ClinicalTrial AI  
+**Product Type:** Conversational AI-based Clinical Trial Management Assistant  
+**Purpose:** To support end-to-end clinical trial activities through intelligent conversation-based automation and documentation without relying on integrations with CTMS, EDC, or EHR systems.
+
+## 2. Target Users / Personas
+
+| Persona | Description |
+| --- | --- |
+| Clinical Project Manager (CPM) | Oversees study setup, milestones, site selection, and vendor management. |
+| Clinical Research Associate (CRA) | Conducts monitoring visits, reviews source data, and ensures compliance. |
+| Medical Monitor / Safety Officer | Reviews AE/SAE reports, oversees signal detection, ensures patient safety. |
+| Data Manager (DM) | Handles CRF design, data cleaning, and query management. |
+| Site Coordinator / Investigator | Coordinates patient visits, ensures protocol adherence. |
+| Regulatory Affairs | Prepares documentation for regulatory submission. |
+
+## 3. Core Features & Functional Requirements
+
+### 3.1 Protocol Design & Study Setup
+
+| Feature | Description |
+| --- | --- |
+| Protocol Outline Generator | Auto-generate Phase I-IV protocol outlines based on indication, route, and design type. |
+| Inclusion/Exclusion Criteria Engine | Generate tailored criteria based on disease, population, and trial type. |
+| Visit Schedule Generator | Output visit tables with procedures by visit (text format). |
+| Adaptive Design Recommender | Suggest adaptive trial features (e.g., sample re-estimation, drop-the-loser). |
+
+### 3.2 Site Selection & Feasibility Support
+
+| Feature | Description |
+| --- | --- |
+| Feasibility Questionnaire Generator | Custom questions for site capabilities, based on therapeutic area and phase. |
+| Site Qualification Checklist | Generate templates for SIV/SQV visits. |
+| Risk Scoring Simulator | Simulate site risk scores using user-defined factors (e.g., past audit history). |
+| Regulatory Consideration Prompter | Provide country-specific regulatory insights (ICH, EMA, FDA, etc.). |
+
+### 3.3 Patient Recruitment Strategy
+
+| Feature | Description |
+| --- | --- |
+| Recruitment Strategy Generator | Output plans by indication and phase. |
+| Digital/DCT Approach Prompter | Suggest telehealth, eConsent, remote monitoring solutions. |
+| Communication Script Writer | Draft patient-facing messages, emails, flyers for recruitment. |
+
+### 3.4 Risk-Based Monitoring (RBM) Planning
+
+| Feature | Description |
+| --- | --- |
+| RBM Plan Writer | Generate sample RBM strategy and roles. |
+| SDV Checklist Creator | Create Source Data Verification checklists by visit or data type. |
+| Central Monitoring SOP Advisor | Recommend steps and workflows for centralized monitoring. |
+
+### 3.5 Safety & Pharmacovigilance Support
+
+| Feature | Description |
+| --- | --- |
+| Safety Narrative Templates | Draft narratives for AE/SAE cases. |
+| MedWatch Form Filler | Generate sample FDA 3500A (MedWatch) form content from provided info. |
+| Signal Detection Guidance | Offer methodology options (disproportionality, trend analysis). |
+| ICH E2A-E2F Explainer | Explain relevant pharmacovigilance guidelines contextually. |
+
+### 3.6 Clinical Documentation & Reporting
+
+| Feature | Description |
+| --- | --- |
+| Monitoring Visit Report (MVR) Generator | Create draft MVRs based on visit notes. |
+| Protocol Deviation Log Creator | Auto-fill deviation logs based on entered info. |
+| Query Log Writer | Structure DM query logs from raw observations. |
+| SOP Writing Assistant | Suggest SOP-ready language for various workflows. |
+
+### 3.7 Timeline & Milestone Planning
+
+| Feature | Description |
+| --- | --- |
+| Enrollment Curve Estimator | Output enrollment forecast descriptions (e.g., 10 pts/month across 5 sites). |
+| Visit Window Generator | Provide day-based visit windows in plain language. |
+| Milestone Planner | Suggest startup-to-DBL timelines based on study type and phase. |
+
+### 3.8 Team & Site Q&A Assistant
+
+| Feature | Description |
+| --- | --- |
+| Document Q&A Chatbot | Reads uploaded ICFs, protocols, manuals to answer user queries. |
+| CRA Onboarding Helper | Summarize study-specific training needs from protocol. |
+| Site FAQ Generator | Create investigator-facing FAQ sheets based on uploaded protocol. |
+
+### 3.9 Bonus Chat-Only Features (No Integration Required)
+
+| Feature | Description |
+| --- | --- |
+| CTD/eCTD Drafting Assistant | Suggest document structure and placement for regulatory submissions. |
+| DSMB Meeting Prep Assistant | Generate briefing materials, timelines, and templates. |
+| Patient Burden Simulator | Estimate visit load, travel, and procedure intensity to inform design decisions. |
+
+## 4. Inputs and Output Formats
+
+**Input Types**
+
+- Free-text queries
+- Structured prompts (e.g., `{ "indication": "NSCLC", "phase": "III" }`)
+- Document uploads (PDF, DOCX)
+- Risk factor matrices
+- Templates for form population
+
+**Output Types**
+
+- Text descriptions (formatted as markdown or bullet lists)
+- Tabular data in plain text (e.g., visit tables)
+- Document text blocks ready for copy-paste into reports or systems
+- Narrative templates
+- Q&A responses to uploaded content
+
+## 5. Non-Functional Requirements
+
+| Requirement | Description |
+| --- | --- |
+| Performance | Responses within 2–5 seconds for most queries |
+| Security | All queries and uploads must be processed without storing PHI or PII |
+| Compliance | Designed in alignment with GCP, ICH, and 21 CFR Part 11 documentation standards |
+| Usability | Conversational UX with minimal learning curve for clinical teams |
+| Language Support | English (default), scalable to multilingual with future training |
+| Availability | Chatbot must operate 24/7 with no downtime dependency on external systems |
+| Extensibility | Can be containerized or integrated into broader CTMS portals later |
+
+## 6. Constraints & Assumptions
+
+- No backend system integrations (CTMS, EHR, EDC) are assumed.
+- The tool does not execute regulatory submissions or send messages.
+- Designed for document generation, knowledge assistance, and planning only.
+- User inputs are assumed to be structured enough for AI interpretation.
+
+## 7. Metrics for Success (KPIs)
+
+| KPI | Goal |
+| --- | --- |
+| Task Completion Rate | >90% (e.g., successful generation of requested documents) |
+| User Satisfaction | >85% CSAT score in pilot surveys |
+| Query Accuracy | >95% factual correctness in regulatory/guideline responses |
+| Time Saved | At least 30% reduction in time to draft documents or templates |
+
+## 8. Future Features (Backlog)
+
+- Integration with EDC/CTMS APIs (optional plugins)
+- Voice-to-text input for field CRAs
+- GxP audit trail support
+- Form-based UI overlay for structured generation
+- Country-specific regulatory rule database


### PR DESCRIPTION
## Summary
- add a standalone product requirements document for the ClinicalTrial AI assistant
- outline personas, functional requirements, inputs/outputs, non-functional needs, and future roadmap

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df298c1e4c832c9ec3bc132eb5e144